### PR TITLE
feat(tx-driver): KernelSigner, backed by a resident wallet kernel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10559,6 +10559,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "hex",
+ "kernels-open-wallet",
  "nockapp",
  "nockapp-grpc",
  "nockapp-grpc-proto",
@@ -10574,6 +10575,7 @@ dependencies = [
  "tokio",
  "tracing",
  "wallet-tx-builder",
+ "zkvm-jetpack",
 ]
 
 [[package]]

--- a/crates/tx-driver/Cargo.toml
+++ b/crates/tx-driver/Cargo.toml
@@ -12,11 +12,16 @@ default = ["nockapp-driver"]
 nockapp-driver = []
 # In-memory ChainSource/Signer mocks, for downstream integration suites.
 testing = []
+# `KernelSigner`, backed by a resident Hoon wallet kernel. Off by default: it
+# pulls in the wallet kernel image and the prover hot state, which a host that
+# signs remotely (a service, a browser extension, WASM) has no use for.
+kernel-signer = ["dep:kernels-open-wallet", "dep:zkvm-jetpack"]
 
 [dependencies]
 async-trait.workspace = true
 bytes.workspace = true
 hex = { workspace = true }
+kernels-open-wallet = { workspace = true, optional = true }
 nockapp.workspace = true
 nockapp-grpc.workspace = true
 nockapp-grpc-proto.workspace = true
@@ -31,10 +36,14 @@ thiserror.workspace = true
 tokio = { workspace = true, features = ["fs", "macros", "rt", "sync", "time"] }
 tracing.workspace = true
 wallet-tx-builder.workspace = true
+zkvm-jetpack = { workspace = true, optional = true }
 
 [dev-dependencies]
 tempfile.workspace = true
 tokio = { workspace = true, features = ["full", "test-util"] }
+
+[package.metadata.docs.rs]
+all-features = true
 
 [lints]
 workspace = true

--- a/crates/tx-driver/README.md
+++ b/crates/tx-driver/README.md
@@ -98,11 +98,32 @@ threshold shortfall — so "insufficient funds" is falsifiable and a UI can say
 can be checked against an expected set so a fork is caught at connect time rather
 than as a silently underpriced transaction.
 
+**Signing against a real wallet kernel** is available behind the `kernel-signer`
+feature. `KernelSigner` boots the Hoon wallet, seeds it with keys and with the
+balance the driver planned against, and pins it to that plan: inputs are named
+explicitly, the fee is passed as a number, and *every* output — change included —
+is handed over as a `%lock-root` order, so the kernel's own change logic has
+nothing left to compute. The signed transaction comes back through the kernel's
+`%file` effect and is decoded in memory; nothing is written to disk.
+
+The feature is off by default because it pulls in the wallet kernel image and
+the prover hot state, which a host that signs remotely has no use for.
+
+> **Requires a current `assets/wal.jam`.** That file is a local build artifact
+> (gitignored), and `make` will not notice when it goes stale: `HOON_SRCS` in the
+> Makefile is written `$(find ...)` rather than `$(shell find ...)`, so it
+> expands to nothing and every jam rule's source dependency list is empty. A jam
+> is therefore only rebuilt when its own entry point changes — never when a
+> library under it does.
+>
+> A kernel older than the `multisig` field `create-tx-cause` grew in
+> `hoon/apps/wallet/lib/types.hoon` rejects the poke outright, as it does the
+> `nockchain-wallet` CLI's own `create-tx`. Rebuild with `make assets/wal.jam`
+> (`rm` it first, or the rule may consider it up to date). A stale kernel shows
+> up as `the wallet kernel built no transaction. It said: ## Poke failed`.
+
 ## Not implemented
 
-- **`KernelSigner`.** The trait, a `RemoteSigner` and a `MockSigner` exist;
-  a wallet-kernel-backed signer does not. Design in
-  [`KERNEL_SIGNER_SPEC.md`](KERNEL_SIGNER_SPEC.md).
 - **Spending from multi-branch lock trees.** `Recipient::to_tree` lets you pay
   *into* one, but `SpendConditionMatcher` derives first-names via the
   single-condition path, so tree-locked notes are not recognised as inputs. They
@@ -119,7 +140,8 @@ than as a silently underpriced transaction.
 ## Testing
 
 ```sh
-cargo test -p tx-driver              # 88 tests
+cargo test -p tx-driver                          # library core, in-memory
+cargo test -p tx-driver --features kernel-signer # adds the wallet-kernel suite
 cargo clippy -p tx-driver --all-targets
 ```
 

--- a/crates/tx-driver/src/driver.rs
+++ b/crates/tx-driver/src/driver.rs
@@ -33,7 +33,7 @@ use crate::error::{RejectReason, Result, TxDriverError};
 use crate::intent::{IntentId, TxIntent, TxOutcome};
 use crate::journal::{cue_raw_tx, IntentState, Journal};
 use crate::notes::{classify, ClassifiedNotes, SpendConditionMatcher, UnlockContext};
-use crate::sign::{validate_signed, SignError, SignRequest, Signer};
+use crate::sign::{validate_signed, ChainState, SignError, SignRequest, Signer};
 
 /// How hard the driver tries to see a transaction land in a block.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -301,7 +301,7 @@ impl TxDriver {
             journal.planned(id).await?;
         }
 
-        let signed = match self.sign(id, &plan, &classified).await {
+        let signed = match self.sign(id, &plan, &classified, &snapshot).await {
             Ok(signed) => signed,
             Err(outcome) => return Ok(outcome),
         };
@@ -391,23 +391,39 @@ impl TxDriver {
         id: IntentId,
         plan: &TxPlan,
         classified: &ClassifiedNotes,
+        snapshot: &crate::chain::BalanceSnapshot,
     ) -> std::result::Result<nockchain_types::tx_engine::v1::RawTx, TxOutcome> {
+        let is_input = |name: &nockchain_types::tx_engine::common::Name| {
+            plan.assembled
+                .inputs
+                .iter()
+                .any(|input| &input.note.name == name)
+        };
+
         // Hand the signer the notes it is actually spending, not the whole
         // wallet: an approval prompt should show the inputs of this
         // transaction.
         let spent: Vec<_> = classified
             .spendable
             .iter()
-            .filter(|candidate| {
-                plan.assembled
-                    .inputs
-                    .iter()
-                    .any(|input| input.note.name == candidate.identity().name)
-            })
+            .filter(|candidate| is_input(&candidate.identity().name))
+            .cloned()
+            .collect();
+        // The same notes as the chain reported them. A signer driving a wallet
+        // kernel has to seed that kernel's balance, and the planner's
+        // `CandidateNote` projection is not enough to rebuild a note from.
+        let spent_notes: Vec<_> = snapshot
+            .notes
+            .iter()
+            .filter(|(name, _)| is_input(name))
             .cloned()
             .collect();
 
-        let request = SignRequest::new(id, plan.clone(), spent);
+        let chain_state = ChainState {
+            height: snapshot.height.clone(),
+            block_id: snapshot.block_id.clone(),
+        };
+        let request = SignRequest::new(id, plan.clone(), spent, chain_state, spent_notes);
         match self.signer.sign(request).await {
             Ok(signed) => Ok(signed),
             Err(err) if err.is_terminal() => {

--- a/crates/tx-driver/src/kernel_signer.rs
+++ b/crates/tx-driver/src/kernel_signer.rs
@@ -1,0 +1,827 @@
+//! [`KernelSigner`] — a [`Signer`] backed by a resident Hoon wallet kernel.
+//!
+//! Rust can *verify* signatures ([`nockchain_types::tx_engine::v1::signatures`])
+//! but cannot *produce* them: Schnorr signing lives only in the Hoon wallet.
+//! So this signer holds a booted wallet kernel and pokes it.
+//!
+//! # The problem this module actually solves
+//!
+//! The kernel's `create-tx` is not "sign this transaction". It is "build *and*
+//! sign a transaction": given a loose request it selects its own notes,
+//! computes its own fee, and decides its own change output. The driver has
+//! already done all three. If the two disagree the signer returns a transaction
+//! the driver never asked for, and [`crate::sign::validate_signed`] rejects it —
+//! correctly, but uselessly.
+//!
+//! Everything here is in service of pinning the kernel to the driver's plan:
+//!
+//! - **Inputs** are named explicitly, so the kernel's selector has exactly one
+//!   legal answer.
+//! - **The fee** is passed as a number, not a policy.
+//! - **Every output, including the change,** is passed as a `%lock-root` order.
+//!   That is the whole trick, and it is worth spelling out: the driver's plan
+//!   already contains the change output, so if the orders are handed over
+//!   *complete*, then `inputs − orders − fee = 0` and the kernel's own refund
+//!   logic drops out (`+create-spends-1` in `tx-builder.hoon` omits the refund
+//!   order when the remainder is zero). The alternative — telling the kernel
+//!   where to send change and letting it compute the amount — reintroduces the
+//!   second opinion this design exists to avoid.
+//!
+//!   `%lock-root` also carries no note-data, which is what the driver plans
+//!   ([`crate::build`] sets `include_data: false`), and it can express a
+//!   destination the `%pkh` and `%multisig` orders cannot: a
+//!   [`crate::intent::Destination::Tree`] or a bare lock root.
+//!
+//! # Residency
+//!
+//! [`nockapp::NockApp::poke_timeout`] returns the effects of one poke directly.
+//! There is no need for an IO driver, and therefore no need for
+//! [`nockapp::NockApp::run`] — which is what makes the wallet CLI one-shot, and
+//! which would have made `%exit` handling load-bearing. The kernel simply lives
+//! in a task that owns it and serves sign jobs off a channel.
+//!
+//! Requests are serialised through that channel on purpose. The kernel is a
+//! single-threaded state machine; the driver's concurrency lives at the intent
+//! level, and `TxDriver` runs each intent on its own task, so a `sign()` that
+//! waits behind another is fine.
+//!
+//! # What never happens
+//!
+//! The kernel reports a built transaction by emitting `[%file %write path jam]`,
+//! and the wallet CLI writes it to disk. This module decodes the jam in memory
+//! and never touches the filesystem: writing it would mean a plaintext signed
+//! transaction on disk, a temp-file race between concurrent signs, and a
+//! filesystem dependency in a code path with no other reason to have one.
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use nockapp::kernel::boot::{self, NockStackSize};
+use nockapp::noun::slab::NounSlab;
+use nockapp::utils::bytes::Byts;
+use nockapp::utils::make_tas;
+use nockapp::wire::{Wire, WireRepr};
+use nockapp::{Bytes, CrownError, NockApp, NockAppError};
+use nockchain_math::belt::Belt;
+use nockchain_math::zoon::zmap::ZMap;
+use nockchain_types::blockchain_constants::BlockchainConstants;
+use nockchain_types::tx_engine::common::{Hash, Name, Signature, Version};
+use nockchain_types::tx_engine::v1;
+use nockvm::jets::cold::Nounable;
+use nockvm::noun::{Cell, Noun, NounAllocator, D, T};
+use noun_serde::{NounDecode, NounEncode};
+use tokio::sync::{mpsc, oneshot};
+use tracing::{debug, info, warn};
+
+use crate::sign::{SignError, SignRequest, Signer};
+
+/// The wire every poke this module sends is tagged with.
+///
+/// The wallet kernel dispatches on `[%poke ?(%one-punch %sys %wallet %file) ..]`
+/// and refuses anything else, so this is not decorative.
+struct WalletPokeWire;
+
+impl Wire for WalletPokeWire {
+    const VERSION: u64 = 1;
+    const SOURCE: &'static str = "one-punch";
+}
+
+fn wire() -> WireRepr {
+    WalletPokeWire.to_wire()
+}
+
+/// Master key material for the wallet kernel, supplied once at boot.
+///
+/// This is deliberately separate from the intent. An intent names the *lock* it
+/// spends from; which keys open that lock is the signer's business and nobody
+/// else's, and key material must never travel in-band through a request.
+#[derive(Clone)]
+pub enum KeySource {
+    /// Generate a fresh master key from caller-supplied entropy and salt.
+    Generate { entropy: [u8; 32], salt: [u8; 16] },
+    /// Import a BIP39-style seed phrase.
+    SeedPhrase { phrase: String, version: u64 },
+    /// Import an extended key (`zprv`/`zpub`).
+    ExtendedKey(String),
+    /// The kernel state at `data_dir` already holds keys. Nothing is poked.
+    Existing,
+}
+
+impl std::fmt::Debug for KeySource {
+    /// Redacted on purpose: a `Debug` that prints a seed phrase turns every
+    /// stray `{:?}` and every panic message into a key leak.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let variant = match self {
+            Self::Generate { .. } => "Generate",
+            Self::SeedPhrase { .. } => "SeedPhrase",
+            Self::ExtendedKey(_) => "ExtendedKey",
+            Self::Existing => "Existing",
+        };
+        write!(f, "KeySource::{variant}(<redacted>)")
+    }
+}
+
+/// How to boot and drive the wallet kernel.
+#[derive(Debug, Clone)]
+pub struct KernelSignerConfig {
+    /// Wallet kernel state directory, reused across restarts. `None` boots an
+    /// ephemeral kernel whose state does not outlive the process — correct for
+    /// tests, wrong for anything holding real keys.
+    pub data_dir: Option<PathBuf>,
+    /// Master key material.
+    pub key_source: KeySource,
+    /// Which derived keys may sign, as `(index, hardened)` pairs. Empty means
+    /// the master key.
+    pub sign_keys: Vec<(u64, bool)>,
+    /// Fakenet/devnet constants. `None` leaves the kernel on mainnet defaults.
+    pub chain_constants: Option<BlockchainConstants>,
+    /// How long to wait for the kernel to answer one *sign* request. On expiry
+    /// the signer reports [`SignError::Unavailable`], which is non-terminal, so
+    /// the intent stays recoverable instead of being falsely written off.
+    ///
+    /// This does not bound [`KernelSigner::new`]. Booting a kernel and
+    /// generating a key are far slower than answering a poke, so holding them
+    /// to a signing budget would force the budget to be useless for signing.
+    /// Construction is a single await the caller owns, so a caller who wants it
+    /// bounded can wrap it in `tokio::time::timeout` — which is not an option
+    /// for the per-request path, because that runs behind a channel.
+    pub timeout: Duration,
+}
+
+impl Default for KernelSignerConfig {
+    fn default() -> Self {
+        Self {
+            data_dir: None,
+            key_source: KeySource::Existing,
+            sign_keys: Vec::new(),
+            chain_constants: None,
+            timeout: Duration::from_secs(300),
+        }
+    }
+}
+
+/// One unit of work for the kernel task.
+struct SignJob {
+    request: SignRequest,
+    reply: oneshot::Sender<Result<v1::RawTx, SignError>>,
+}
+
+/// A [`Signer`] backed by a resident Hoon wallet kernel.
+pub struct KernelSigner {
+    jobs: mpsc::Sender<SignJob>,
+    pkhs: Vec<Hash>,
+    /// The task owning the kernel.
+    ///
+    /// Held for diagnostics only — it is *not* what shuts the kernel down.
+    /// Dropping a `JoinHandle` detaches the task rather than aborting it; what
+    /// actually ends the loop is `jobs` being dropped along with this struct,
+    /// which closes the channel, which makes `recv` return `None`, which drops
+    /// the `NockApp`. Aborting would be worse: it could cut the task off
+    /// mid-poke and leave the kernel's on-disk state torn.
+    _kernel: tokio::task::JoinHandle<()>,
+}
+
+impl KernelSigner {
+    /// Boots a wallet kernel, seeds it with keys, and starts serving.
+    ///
+    /// The derived public-key hashes are read back and cached here rather than
+    /// peeked per call, because [`Signer::signer_pkhs`] is on the *planning*
+    /// path: `TxDriver` builds its [`crate::notes::UnlockContext`] from it, so
+    /// a note needing a key this kernel does not hold is reported as a
+    /// threshold shortfall during planning instead of exploding at signing
+    /// time.
+    pub async fn new(config: KernelSignerConfig) -> Result<Self, SignError> {
+        let timeout = config.timeout;
+        let mut app = boot_wallet(&config).await?;
+
+        if let Some(constants) = &config.chain_constants {
+            setup_poke(&mut app, fakenet_poke(constants)).await?;
+        }
+
+        seed_keys(&mut app, &config.key_source).await?;
+
+        let pkhs = read_signer_pkhs(&mut app).await?;
+        if pkhs.is_empty() {
+            return Err(SignError::NoSuchKey(
+                "the wallet kernel holds no signing keys after seeding; check `key_source`".into(),
+            ));
+        }
+        info!(keys = pkhs.len(), "kernel signer ready");
+
+        let sign_keys = config.sign_keys.clone();
+        let (jobs, mut inbox) = mpsc::channel::<SignJob>(32);
+        let kernel = tokio::spawn(async move {
+            while let Some(job) = inbox.recv().await {
+                let result = sign_one(&mut app, &job.request, &sign_keys, timeout).await;
+                // A dropped receiver means the caller gave up. The transaction
+                // was built but never left this process, so there is nothing to
+                // clean up — but it is worth saying out loud, because the
+                // kernel did the work.
+                if job.reply.send(result).is_err() {
+                    warn!(
+                        intent = %job.request.intent_id,
+                        "sign result discarded: the caller stopped waiting"
+                    );
+                }
+            }
+            debug!("kernel signer shutting down: no more senders");
+        });
+
+        Ok(Self {
+            jobs,
+            pkhs,
+            _kernel: kernel,
+        })
+    }
+}
+
+#[async_trait]
+impl Signer for KernelSigner {
+    async fn signer_pkhs(&self) -> Result<Vec<Hash>, SignError> {
+        Ok(self.pkhs.clone())
+    }
+
+    async fn sign(&self, request: SignRequest) -> Result<v1::RawTx, SignError> {
+        let (reply, answer) = oneshot::channel();
+        self.jobs
+            .send(SignJob { request, reply })
+            .await
+            .map_err(|_| SignError::Unavailable("the wallet kernel task has stopped".into()))?;
+        answer.await.map_err(|_| {
+            SignError::Unavailable("the wallet kernel task dropped the request".into())
+        })?
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Boot and seeding
+// ---------------------------------------------------------------------------
+
+async fn boot_wallet(config: &KernelSignerConfig) -> Result<NockApp, SignError> {
+    let mut cli = boot::default_boot_cli(config.data_dir.is_none());
+    // The wallet kernel is small; the wallet CLI runs it on `Tiny` too.
+    cli.stack_size = NockStackSize::Tiny;
+    if config.data_dir.is_none() {
+        cli.ephemeral = true;
+    }
+
+    let hot_state = zkvm_jetpack::hot::produce_prover_hot_state();
+    boot::setup(
+        kernels_open_wallet::KERNEL,
+        cli,
+        hot_state.as_slice(),
+        "wallet",
+        config.data_dir.clone(),
+    )
+    .await
+    .map_err(|err| SignError::Unavailable(format!("wallet kernel failed to boot: {err}")))
+}
+
+async fn seed_keys(app: &mut NockApp, source: &KeySource) -> Result<(), SignError> {
+    let mut slab: NounSlab = NounSlab::new();
+    let cause = match source {
+        KeySource::Existing => return Ok(()),
+        KeySource::Generate { entropy, salt } => {
+            let entropy = byts_noun(&mut slab, entropy);
+            let salt = byts_noun(&mut slab, salt);
+            command(&mut slab, "keygen", &[entropy, salt])
+        }
+        KeySource::SeedPhrase { phrase, version } => {
+            let phrase = make_tas(&mut slab, phrase).as_noun();
+            let version = version.to_noun(&mut slab);
+            command(&mut slab, "import-seed-phrase", &[phrase, version])
+        }
+        KeySource::ExtendedKey(key) => {
+            let key = make_tas(&mut slab, key).as_noun();
+            command(&mut slab, "import-extended", &[key])
+        }
+    };
+    slab.set_root(cause);
+    setup_poke(app, slab).await?;
+    Ok(())
+}
+
+/// Reads the derived public-key hashes the kernel can sign for.
+///
+/// Mirrors the wallet CLI's fallback chain (`resolve_planner_signer_keys`):
+/// tracked signing keys first, then active signer entries, then the master key.
+/// A kernel seeded by `keygen` populates the first; one seeded by watching an
+/// address may only populate the last.
+async fn read_signer_pkhs(app: &mut NockApp) -> Result<Vec<Hash>, SignError> {
+    let mut keys = peek_hashes(app, "signing-keys").await?;
+    if keys.is_empty() {
+        if let Some(master) = peek_hash(app, "master-signing-key").await? {
+            keys.push(master);
+        }
+    }
+    keys.sort_by_key(Hash::to_array);
+    keys.dedup_by(|left, right| left.to_array() == right.to_array());
+    Ok(keys)
+}
+
+async fn peek_hashes(app: &mut NockApp, path_tag: &str) -> Result<Vec<Hash>, SignError> {
+    let result = peek(app, path_tag).await?;
+    let space = result.noun_space();
+    let decoded: Option<Option<Vec<Hash>>> =
+        unsafe { <Option<Option<Vec<Hash>>>>::from_noun(result.root(), &space) }
+            .map_err(|err| SignError::Undecodable(format!("{path_tag} peek: {err}")))?;
+    Ok(decoded.flatten().unwrap_or_default())
+}
+
+async fn peek_hash(app: &mut NockApp, path_tag: &str) -> Result<Option<Hash>, SignError> {
+    let result = peek(app, path_tag).await?;
+    let space = result.noun_space();
+    let decoded: Option<Option<Hash>> =
+        unsafe { <Option<Option<Hash>>>::from_noun(result.root(), &space) }
+            .map_err(|err| SignError::Undecodable(format!("{path_tag} peek: {err}")))?;
+    Ok(decoded.flatten())
+}
+
+async fn peek(app: &mut NockApp, path_tag: &str) -> Result<NounSlab, SignError> {
+    let mut slab: NounSlab = NounSlab::new();
+    let tag = make_tas(&mut slab, path_tag).as_noun();
+    let path = T(&mut slab, &[tag, D(0)]);
+    slab.set_root(path);
+    app.peek(slab)
+        .await
+        .map_err(|err| classify(err, &format!("peek {path_tag}")))
+}
+
+// ---------------------------------------------------------------------------
+// Signing one request
+// ---------------------------------------------------------------------------
+
+async fn sign_one(
+    app: &mut NockApp,
+    request: &SignRequest,
+    sign_keys: &[(u64, bool)],
+    timeout: Duration,
+) -> Result<v1::RawTx, SignError> {
+    // The kernel selects from the balance in its own state, so the notes being
+    // spent have to be pushed in. Fetching them independently would give the
+    // kernel a second view of the chain and a plan it cannot reproduce.
+    let balance = v1::BalanceUpdate {
+        height: request.chain_state.height.clone(),
+        block_id: request.chain_state.block_id.clone(),
+        notes: v1::note::Balance(request.spent_notes.clone()),
+    };
+    poke_kernel(app, update_balance_poke(&balance), timeout).await?;
+
+    let poke = create_tx_poke(request, sign_keys)?;
+    let effects = poke_kernel(app, poke, timeout).await?;
+
+    let jam = written_transaction(&effects).ok_or_else(|| {
+        // The kernel's only channel for saying *why* is a `%markdown` effect
+        // meant for a human reading a terminal. Forwarding it verbatim is ugly
+        // but it is the difference between a debuggable failure and a shrug.
+        SignError::Declined(format!(
+            "the wallet kernel built no transaction. It said: {}",
+            kernel_explanation(&effects)
+        ))
+    })?;
+    let signed = decode_transaction(&jam)?;
+
+    // `validate_signed` catches a divergence regardless, two layers up, as an
+    // opaque `SignerMismatch`. Checking here costs nothing and names the actual
+    // problem: the kernel re-planned.
+    ensure_input_parity(request, &signed)?;
+    Ok(signed)
+}
+
+/// Fails when the kernel spent a different set of notes than was named.
+///
+/// A mismatch means the kernel ignored the explicit `names` list and ran its
+/// own selector, which also means its fee is its own — so the diagnosis is
+/// "planner parity", not "bad signature".
+fn ensure_input_parity(request: &SignRequest, signed: &v1::RawTx) -> Result<(), SignError> {
+    let mut requested: Vec<_> = request
+        .plan
+        .assembled
+        .inputs
+        .iter()
+        .map(|input| name_key(&input.note.name))
+        .collect();
+    let mut actual: Vec<_> = signed
+        .spends
+        .0
+        .iter()
+        .map(|(name, _)| name_key(name))
+        .collect();
+    requested.sort_unstable();
+    actual.sort_unstable();
+
+    if requested != actual {
+        return Err(SignError::Declined(format!(
+            "planner parity mismatch: the driver named {} input note(s) but the wallet kernel \
+             spent {}, so its fee and change are its own rather than the driver's",
+            requested.len(),
+            actual.len()
+        )));
+    }
+    Ok(())
+}
+
+fn name_key(name: &Name) -> ([u64; 5], [u64; 5]) {
+    (name.first.to_array(), name.last.to_array())
+}
+
+// ---------------------------------------------------------------------------
+// Poke encoding
+// ---------------------------------------------------------------------------
+
+/// Builds the `[%create-tx ..]` cause pinning the kernel to `request.plan`.
+///
+/// The cause is the 10-tuple `create-tx-cause` from
+/// `hoon/apps/wallet/lib/types.hoon`:
+///
+/// ```text
+/// [names orders fee allow-low-fee sign-keys refund-pkh
+///  include-data save-raw-tx selection-strategy multisig]
+/// ```
+fn create_tx_poke(request: &SignRequest, sign_keys: &[(u64, bool)]) -> Result<NounSlab, SignError> {
+    let plan = &request.plan;
+    let mut slab: NounSlab = NounSlab::new();
+
+    // `names` — the whole mechanism. An explicit list leaves the kernel's
+    // selector exactly one legal answer.
+    let names = plan.assembled.inputs.iter().rev().fold(D(0), |acc, input| {
+        let first = make_tas(&mut slab, &input.note.name.first.to_base58()).as_noun();
+        let last = make_tas(&mut slab, &input.note.name.last.to_base58()).as_noun();
+        let pair = T(&mut slab, &[first, last]);
+        Cell::new(&mut slab, pair, acc).as_noun()
+    });
+
+    // `orders` — *every* planned output, change included, as `%lock-root`. See
+    // the module docs: this is what drives the kernel's own refund to zero.
+    let orders = plan
+        .assembled
+        .outputs
+        .iter()
+        .rev()
+        .fold(D(0), |acc, output| {
+            let tag = make_tas(&mut slab, "lock-root").as_noun();
+            let root = output.lock_root.to_noun(&mut slab);
+            let gift = output.amount.to_noun(&mut slab);
+            let order = T(&mut slab, &[tag, root, gift]);
+            Cell::new(&mut slab, order, acc).as_noun()
+        });
+
+    let fee = plan.assembled.fee.to_noun(&mut slab);
+    // `allow-low-fee` stays false. The driver's fee is planner-computed; if the
+    // kernel thinks it is too low, that is a parity failure worth hearing about
+    // rather than suppressing.
+    let allow_low_fee = false.to_noun(&mut slab);
+    let sign_keys_noun = if sign_keys.is_empty() {
+        D(0)
+    } else {
+        Some(sign_keys.to_vec()).to_noun(&mut slab)
+    };
+    // `refund-pkh` is `~`: the orders above already account for every nick, so
+    // the kernel has no change to place.
+    let refund = D(0);
+    // Must match `PlanRequest::include_data` in `build.rs`. Disagreeing changes
+    // the word count, which changes the fee, which fails parity.
+    let include_data = false.to_noun(&mut slab);
+    // No debug jams. The transaction comes back through the `%file %write`
+    // effect and is decoded in memory.
+    let save_raw_tx = false.to_noun(&mut slab);
+    // Irrelevant under an explicit `names` list, but the field is not optional.
+    let selection = make_tas(&mut slab, "asc").as_noun();
+    let multisig = multisig_noun(&mut slab, request)?;
+
+    let cause = T(
+        &mut slab,
+        &[
+            names, orders, fee, allow_low_fee, sign_keys_noun, refund, include_data, save_raw_tx,
+            selection, multisig,
+        ],
+    );
+    let full = command(&mut slab, "create-tx", &[cause]);
+    slab.set_root(full);
+    Ok(slab)
+}
+
+/// Builds the `multisig` field: the threshold and participants of an m-of-n
+/// input lock.
+///
+/// A multisig note's note-data omits its lock, so the kernel cannot recover it
+/// from the note alone and has to be handed the participants to rebuild it
+/// from. A 1-of-1 lock needs none of this, and passing it anyway would make the
+/// kernel reconstruct a lock it can already derive.
+///
+/// Only one such lock is supported per transaction, because the cause has room
+/// for exactly one and every input is built against it.
+fn multisig_noun(slab: &mut NounSlab, request: &SignRequest) -> Result<Noun, SignError> {
+    let multisig: Vec<_> = request
+        .plan
+        .spend_conditions
+        .iter()
+        .filter_map(|condition| condition.required_pkh_policy())
+        .filter(|policy| policy.threshold > 1 || policy.hashes.len() > 1)
+        .collect();
+
+    let policy =
+        match multisig.as_slice() {
+            [] => return Ok(D(0)),
+            [only] => only,
+            _ => return Err(SignError::Declined(
+                "this transaction spends notes under more than one multisig lock, and the wallet \
+                 kernel can rebuild only one input lock per transaction; split the intent"
+                    .into(),
+            )),
+        };
+
+    let participants = policy.hashes.iter().rev().fold(D(0), |acc, hash| {
+        let participant = make_tas(slab, &hash.to_base58()).as_noun();
+        Cell::new(slab, participant, acc).as_noun()
+    });
+    let threshold = (policy.threshold as u64).to_noun(slab);
+    let payload = T(slab, &[threshold, participants]);
+    Ok(T(slab, &[D(0), payload]))
+}
+
+fn update_balance_poke(balance: &v1::BalanceUpdate) -> NounSlab {
+    let mut slab: NounSlab = NounSlab::new();
+    // Double-wrapped to match the kernel's `(unit (unit balance-update))`.
+    let wrapped = Some(Some(balance.clone())).to_noun(&mut slab);
+    let full = command(&mut slab, "update-balance-grpc", &[wrapped]);
+    slab.set_root(full);
+    slab
+}
+
+fn fakenet_poke(constants: &BlockchainConstants) -> NounSlab {
+    let mut slab: NounSlab = NounSlab::new();
+    let noun = constants.to_noun(&mut slab);
+    let full = command(&mut slab, "fakenet", &[noun]);
+    slab.set_root(full);
+    slab
+}
+
+/// Wraps arguments into the `[%verb args]` cause shape every wallet poke uses.
+fn command(slab: &mut NounSlab, verb: &str, args: &[Noun]) -> Noun {
+    let head = make_tas(slab, verb).as_noun();
+    let tail = match args.len() {
+        0 => D(0),
+        1 => args[0],
+        _ => T(slab, args),
+    };
+    T(slab, &[head, tail])
+}
+
+fn byts_noun(slab: &mut NounSlab, bytes: &[u8]) -> Noun {
+    Byts::new(bytes.to_vec()).into_noun(slab)
+}
+
+// ---------------------------------------------------------------------------
+// Effect decoding
+// ---------------------------------------------------------------------------
+
+/// Extracts the jammed transaction from a `[%file %write path contents]`
+/// effect, without writing anything.
+///
+/// The kernel also emits `%markdown`, and emits `%exit` on the failure path;
+/// both are ignored. Nothing here forwards `%exit` anywhere, which is what lets
+/// the kernel survive more than one signature.
+fn written_transaction(effects: &[NounSlab]) -> Option<Bytes> {
+    for effect in effects {
+        let space = effect.noun_space();
+        let noun = unsafe { effect.root() };
+        let Ok(cell) = noun.in_space(&space).as_cell() else {
+            continue;
+        };
+        let Ok(tag) = String::from_noun(&cell.head().noun(), &space) else {
+            continue;
+        };
+        if tag != "file" {
+            continue;
+        }
+        let Ok(body) = cell.tail().as_cell() else {
+            continue;
+        };
+        let Ok(operation) = String::from_noun(&body.head().noun(), &space) else {
+            continue;
+        };
+        if operation != "write" {
+            continue;
+        }
+        if let Ok((_path, contents)) = <(String, Bytes)>::from_noun(&body.tail().noun(), &space) {
+            return Some(contents);
+        }
+    }
+    None
+}
+
+/// Markers that identify a `%markdown` effect carrying key material.
+///
+/// The wallet kernel answers `keygen` and the `import-*` commands with a
+/// human-facing report containing the seed phrase and the extended private key
+/// in plaintext. Nothing here should ever forward one of those.
+const SECRET_MARKERS: [&str; 4] = ["Seed Phrase", "Extended Private Key", "zprv", "Master Key"];
+
+/// Collects whatever the kernel said in `%markdown` effects.
+///
+/// `## Poke failed` in particular means the kernel's `soft` rejected the cause
+/// outright — the built kernel image and the cause this module encodes have
+/// drifted apart — which is worth being able to recognise on sight.
+///
+/// # Why this filters
+///
+/// The string this returns ends up inside a [`SignError`], which the driver
+/// turns into a `RejectReason`, which it journals to disk and pokes back to the
+/// kernel as a `%tx-rejected` cause. So this is a pipe from kernel output to
+/// durable storage and to a log, and the wallet kernel's `%markdown` channel is
+/// also how it prints seed phrases.
+///
+/// Today only the `create-tx` response reaches here, and that response carries
+/// no key material. That is a fact about the current call graph, not a
+/// property of this function, and it is exactly the kind of fact that stops
+/// being true quietly. Rather than rely on it, anything bearing a key-material
+/// marker is dropped outright — the whole point of this crate's design is that
+/// key material never reaches a journal or a log.
+fn kernel_explanation(effects: &[NounSlab]) -> String {
+    let mut redacted = false;
+    let messages: Vec<String> = effects
+        .iter()
+        .filter_map(|effect| {
+            let space = effect.noun_space();
+            let noun = unsafe { effect.root() };
+            let cell = noun.in_space(&space).as_cell().ok()?;
+            if String::from_noun(&cell.head().noun(), &space).ok()? != "markdown" {
+                return None;
+            }
+            let message = String::from_noun(&cell.tail().noun(), &space).ok()?;
+            if SECRET_MARKERS.iter().any(|marker| message.contains(marker)) {
+                redacted = true;
+                return None;
+            }
+            Some(message)
+        })
+        .collect();
+
+    match (messages.is_empty(), redacted) {
+        (true, true) => "<redacted: the kernel's reply carried key material>".into(),
+        (true, false) => "nothing at all — it emitted no diagnostic effect".into(),
+        _ => messages.join(" / ").replace('\n', " "),
+    }
+}
+
+/// Cues a saved `transaction-1` and reassembles it into a [`v1::RawTx`].
+///
+/// The envelope is `[%1 name spends metadata witness-data]`: the signatures
+/// live in `witness-data`, keyed by note name, rather than inside the spends.
+/// Reattaching them is what turns the saved form back into a raw transaction.
+///
+/// The transaction id is recomputed from the reassembled contents rather than
+/// read from the envelope's `name` field, so the id this returns is the one the
+/// network will derive. [`crate::sign::validate_signed`] checks it again.
+fn decode_transaction(jam: &Bytes) -> Result<v1::RawTx, SignError> {
+    let undecodable = |message: String| SignError::Undecodable(message);
+
+    let mut slab: NounSlab = NounSlab::new();
+    let root = slab
+        .cue_into(jam.clone())
+        .map_err(|err| undecodable(format!("saved transaction did not cue: {err}")))?;
+    let space = slab.noun_space();
+
+    let cell = root
+        .in_space(&space)
+        .as_cell()
+        .map_err(|err| undecodable(format!("saved transaction root is not a cell: {err}")))?;
+    let version = <u64 as NounDecode>::from_noun(&cell.head().noun(), &space)
+        .map_err(|err| undecodable(format!("saved transaction version: {err}")))?;
+    if version != 1 {
+        return Err(undecodable(format!(
+            "expected a version 1 saved transaction, got {version}"
+        )));
+    }
+
+    let after_name = cell
+        .tail()
+        .as_cell()
+        .map_err(|err| undecodable(format!("saved transaction has no name: {err}")))?;
+    let after_spends = after_name
+        .tail()
+        .as_cell()
+        .map_err(|err| undecodable(format!("saved transaction has no spends: {err}")))?;
+    let mut spends = v1::Spends::from_noun(&after_spends.head().noun(), &space)
+        .map_err(|err| undecodable(format!("saved transaction spends: {err}")))?;
+
+    let after_metadata = after_spends
+        .tail()
+        .as_cell()
+        .map_err(|err| undecodable(format!("saved transaction has no witness-data: {err}")))?;
+    let witness_data = after_metadata
+        .tail()
+        .as_cell()
+        .map_err(|err| undecodable(format!("witness-data is not a cell: {err}")))?;
+    let witness_tag = <u64 as NounDecode>::from_noun(&witness_data.head().noun(), &space)
+        .map_err(|err| undecodable(format!("witness-data tag: {err}")))?;
+
+    match witness_tag {
+        0 => {
+            let signatures =
+                ZMap::<Name, Signature>::from_noun(&witness_data.tail().noun(), &space)
+                    .map_err(|err| undecodable(format!("legacy witness-data: {err}")))?;
+            for (name, signature) in signatures.into_entries() {
+                let Some((_, v1::Spend::Legacy(spend0))) = spends
+                    .0
+                    .iter_mut()
+                    .find(|(candidate, _)| *candidate == name)
+                else {
+                    return Err(undecodable(format!(
+                        "witness-data names a spend the transaction does not have: {}",
+                        name.first.to_base58()
+                    )));
+                };
+                spend0.signature = signature;
+            }
+        }
+        1 => {
+            let witnesses =
+                ZMap::<Name, v1::Witness>::from_noun(&witness_data.tail().noun(), &space)
+                    .map_err(|err| undecodable(format!("v1 witness-data: {err}")))?;
+            for (name, witness) in witnesses.into_entries() {
+                let Some((_, v1::Spend::Witness(spend1))) = spends
+                    .0
+                    .iter_mut()
+                    .find(|(candidate, _)| *candidate == name)
+                else {
+                    return Err(undecodable(format!(
+                        "witness-data names a spend the transaction does not have: {}",
+                        name.first.to_base58()
+                    )));
+                };
+                spend1.witness = witness;
+            }
+        }
+        other => return Err(undecodable(format!("unsupported witness-data tag {other}"))),
+    }
+
+    let mut tx = v1::RawTx {
+        version: Version::V1,
+        id: Hash([Belt(0); 5]),
+        spends,
+    };
+    tx.id = tx
+        .compute_id()
+        .map_err(|err| undecodable(format!("reassembled transaction id: {err}")))?;
+    Ok(tx)
+}
+
+// ---------------------------------------------------------------------------
+// Kernel plumbing
+// ---------------------------------------------------------------------------
+
+/// A poke issued during construction, unbounded. See `KernelSignerConfig::timeout`.
+async fn setup_poke(app: &mut NockApp, poke: NounSlab) -> Result<Vec<NounSlab>, SignError> {
+    app.poke(wire(), poke)
+        .await
+        .map_err(|err| classify(err, "setup poke"))
+}
+
+async fn poke_kernel(
+    app: &mut NockApp,
+    poke: NounSlab,
+    timeout: Duration,
+) -> Result<Vec<NounSlab>, SignError> {
+    app.poke_timeout(wire(), poke, timeout)
+        .await
+        .map_err(|err| classify(err, "poke"))
+}
+
+/// Maps a kernel failure onto the right terminal/non-terminal [`SignError`].
+///
+/// This split is load-bearing: `SignError::is_terminal` decides whether the
+/// driver reports a terminal `Rejected` (safe to roll back against) or a
+/// retryable `Failed` (status unknown). Getting it backwards either strands a
+/// recoverable intent or invites a second transaction against the same notes.
+///
+/// The rule is *whether a retry could ever succeed*. A timeout or a dead
+/// channel says nothing about the request, so it is non-terminal. A Hoon crash
+/// is deterministic: the same poke will crash again.
+fn classify(err: NockAppError, context: &str) -> SignError {
+    match err {
+        // Both spellings matter. `poke_timeout` reports a lapsed deadline as
+        // `CrownError::Timeout` rather than `NockAppError::Timeout`, and
+        // missing that variant silently turns every hung kernel into a
+        // terminal rejection — the one classification error this whole split
+        // exists to prevent.
+        NockAppError::Timeout | NockAppError::CrownError(CrownError::Timeout) => {
+            SignError::Unavailable(format!(
+                "the wallet kernel did not answer within the configured timeout ({context})"
+            ))
+        }
+        NockAppError::ChannelClosedError
+        | NockAppError::MPSCSendError(_)
+        | NockAppError::OneShotRecvError(_)
+        | NockAppError::JoinError(_)
+        | NockAppError::IoError(_) => SignError::Unavailable(format!(
+            "the wallet kernel is not reachable ({context}): {err}"
+        )),
+        other => SignError::Declined(format!("the wallet kernel refused the {context}: {other}")),
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/tx-driver/src/kernel_signer/tests.rs
+++ b/crates/tx-driver/src/kernel_signer/tests.rs
@@ -1,0 +1,562 @@
+//! Conformance tests for [`KernelSigner`], against a real Hoon wallet kernel.
+//!
+//! These boot the actual wallet kernel, so they are slow and they are the only
+//! place in this crate where a Hoon signature is produced. That is the point: a
+//! signer that is only ever exercised against a mock proves nothing about the
+//! kernel it is meant to drive, and the failure mode this module exists to
+//! prevent — the kernel quietly re-planning the transaction — is invisible to
+//! any test that does not run the kernel.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use nockchain_math::belt::Belt;
+use nockchain_types::blockchain_constants::default_fakenet_blockchain_constants;
+use nockchain_types::tx_engine::common::{BlockHeight, Hash, Name};
+use nockchain_types::tx_engine::v1;
+use nockchain_types::tx_engine::v1::tx::{LockPrimitive, Pkh, SpendCondition};
+use wallet_tx_builder::types::ChainContext;
+
+use super::*;
+use crate::build::plan;
+use crate::chain::ChainSource;
+use crate::driver::{ConfirmPolicy, TxDriver, TxDriverConfig};
+use crate::intent::{FeePolicy, IntentId, NoteSelection, Recipient, TxIntent, TxOutcome};
+use crate::notes::{classify as classify_notes, SpendConditionMatcher, UnlockContext};
+use crate::sign::validate_signed;
+use crate::testing::{note_for, MockChainSource};
+
+const HEIGHT: u64 = 1_000;
+
+/// A `ChainContext` derived from the same constants the kernel is given.
+///
+/// This has to line up. The driver prices the transaction from these numbers
+/// and pins the result; the kernel re-checks that fee against its *own*
+/// constants and, with `allow-low-fee` false, refuses anything short. Two sets
+/// of constants means a fee the kernel rejects for reasons that have nothing to
+/// do with the driver being wrong.
+fn chain_context() -> ChainContext {
+    let constants = default_fakenet_blockchain_constants();
+    ChainContext {
+        height: BlockHeight(Belt(HEIGHT)),
+        bythos_phase: BlockHeight(Belt(constants.bythos_phase)),
+        base_fee: constants.base_fee,
+        input_fee_divisor: constants.input_fee_divisor,
+        min_fee: constants.note_data.min_fee,
+    }
+}
+
+/// Boots a signer holding a freshly generated key.
+///
+/// `seed` varies the entropy so two signers in one test hold different keys —
+/// which is what makes "a note this signer cannot open" expressible.
+async fn signer_with_key(seed: u8) -> (Arc<KernelSigner>, Hash) {
+    let signer = KernelSigner::new(KernelSignerConfig {
+        data_dir: None,
+        key_source: KeySource::Generate {
+            entropy: [seed; 32],
+            salt: [seed.wrapping_add(1); 16],
+        },
+        sign_keys: Vec::new(),
+        chain_constants: Some(default_fakenet_blockchain_constants()),
+        timeout: Duration::from_secs(300),
+    })
+    .await
+    .expect("the wallet kernel boots and generates a key");
+
+    let pkh = signer
+        .signer_pkhs()
+        .await
+        .expect("signer reports its keys")
+        .first()
+        .cloned()
+        .expect("keygen produces at least one signing key");
+
+    (Arc::new(signer), pkh)
+}
+
+/// A driver wired to `signer` over a chain holding `notes`.
+async fn driver_with(
+    signer: Arc<KernelSigner>,
+    notes: Vec<(Name, v1::Note)>,
+    journal: &tempfile::TempDir,
+) -> (Arc<TxDriver>, Arc<MockChainSource>) {
+    let chain = Arc::new(MockChainSource::new(HEIGHT, notes).with_context(chain_context()));
+    let driver = TxDriver::new(
+        TxDriverConfig {
+            journal_dir: journal.path().to_path_buf(),
+            confirm: ConfirmPolicy::NoWait,
+            ..TxDriverConfig::default()
+        },
+        Arc::clone(&chain) as Arc<dyn ChainSource>,
+        signer as Arc<dyn crate::sign::Signer>,
+    )
+    .await
+    .expect("journal opens");
+    (Arc::new(driver), chain)
+}
+
+fn payment(id: u128, from: SpendCondition, to: Hash, amount: u64) -> TxIntent {
+    TxIntent {
+        id: IntentId::from_u128(id),
+        from: vec![from],
+        recipients: vec![Recipient::to_pkh(to, amount)],
+        refund_to: None,
+        fee: FeePolicy::Auto,
+        note_selection: NoteSelection::Auto,
+        deadline: None,
+    }
+}
+
+/// Plans an intent the way the driver does, so a test can hand the resulting
+/// plan straight to the signer without going through submission.
+async fn plan_for(
+    chain: &MockChainSource,
+    signer: &KernelSigner,
+    intent: &TxIntent,
+) -> (crate::build::TxPlan, SignRequest) {
+    let (matcher, _) = SpendConditionMatcher::new(intent.from.clone());
+    let context = UnlockContext::new()
+        .with_signer_pkhs(signer.signer_pkhs().await.expect("signer reports its keys"));
+    let snapshot = chain
+        .balance(&matcher.first_names())
+        .await
+        .expect("mock chain answers");
+    let classified = classify_notes(&snapshot, &matcher, &context);
+    let plan =
+        plan(intent, &classified, &matcher, &context, &chain_context()).expect("the intent plans");
+
+    let spent = snapshot
+        .notes
+        .iter()
+        .filter(|(name, _)| {
+            plan.assembled
+                .inputs
+                .iter()
+                .any(|input| &input.note.name == name)
+        })
+        .cloned()
+        .collect::<Vec<_>>();
+    let request = SignRequest::new(
+        intent.id,
+        plan.clone(),
+        Vec::new(),
+        crate::sign::ChainState {
+            height: snapshot.height.clone(),
+            block_id: snapshot.block_id.clone(),
+        },
+        spent,
+    );
+    (plan, request)
+}
+
+// ---------------------------------------------------------------------------
+
+/// §7.1 — the baseline. If this fails nothing else matters.
+#[tokio::test]
+async fn a_kernel_signature_validates_against_the_plan() {
+    let (signer, pkh) = signer_with_key(7).await;
+    let lock = SpendCondition::simple_pkh(pkh.clone());
+    let (name, note) = note_for(&lock, 1, 1, 1_000_000);
+
+    let chain = MockChainSource::new(HEIGHT, vec![(name, note)]).with_context(chain_context());
+    let intent = payment(1, lock, crate::testing::hash(500), 100_000);
+    let (plan, request) = plan_for(&chain, &signer, &intent).await;
+
+    let signed = signer.sign(request).await.expect("the kernel signs");
+    validate_signed(&plan, &signed).expect("the kernel's transaction is the driver's transaction");
+}
+
+/// §7.2 — the failure this whole module is built to prevent. `validate_signed`
+/// would catch a divergence anyway; asserting on the transaction directly is
+/// what makes it clear *which* thing diverged.
+#[tokio::test]
+async fn the_kernel_spends_the_planned_inputs_and_charges_the_planned_fee() {
+    let (signer, pkh) = signer_with_key(11).await;
+    let lock = SpendCondition::simple_pkh(pkh.clone());
+    // Several notes, so an unconstrained kernel has room to select differently.
+    let notes: Vec<_> = (0..4)
+        .map(|i| note_for(&lock, 100 + i, 1, 300_000))
+        .collect();
+
+    let chain = MockChainSource::new(HEIGHT, notes).with_context(chain_context());
+    let intent = payment(2, lock, crate::testing::hash(500), 700_000);
+    let (plan, request) = plan_for(&chain, &signer, &intent).await;
+
+    let signed = signer.sign(request).await.expect("the kernel signs");
+
+    let mut planned: Vec<_> = plan
+        .assembled
+        .inputs
+        .iter()
+        .map(|input| input.note.name.first.to_base58())
+        .collect();
+    let mut actual: Vec<_> = signed
+        .spends
+        .0
+        .iter()
+        .map(|(name, _)| name.first.to_base58())
+        .collect();
+    planned.sort();
+    actual.sort();
+    assert_eq!(actual, planned, "the kernel selected its own inputs");
+
+    let charged: u64 = signed
+        .spends
+        .0
+        .iter()
+        .map(|(_, spend)| match spend {
+            v1::Spend::Witness(spend1) => spend1.fee.0 as u64,
+            v1::Spend::Legacy(spend0) => spend0.fee.0 as u64,
+        })
+        .sum();
+    assert_eq!(charged, plan.assembled.fee, "the kernel repriced the fee");
+}
+
+/// §7.3 — the residency test. A kernel that dies after one signature passes
+/// every other test in this file.
+#[tokio::test]
+async fn one_signer_serves_three_signatures() {
+    let (signer, pkh) = signer_with_key(13).await;
+    let lock = SpendCondition::simple_pkh(pkh.clone());
+    let notes: Vec<_> = (0..3)
+        .map(|i| note_for(&lock, 200 + i, 1, 500_000))
+        .collect();
+
+    for (round, (name, note)) in notes.into_iter().enumerate() {
+        let chain = MockChainSource::new(HEIGHT, vec![(name, note)]).with_context(chain_context());
+        let intent = payment(
+            10 + round as u128,
+            lock.clone(),
+            crate::testing::hash(500),
+            100_000,
+        );
+        let (plan, request) = plan_for(&chain, &signer, &intent).await;
+        let signed = signer
+            .sign(request)
+            .await
+            .unwrap_or_else(|err| panic!("signature {} failed: {err}", round + 1));
+        validate_signed(&plan, &signed)
+            .unwrap_or_else(|err| panic!("signature {} did not validate: {err}", round + 1));
+    }
+}
+
+/// §7.4 — two intents in flight against one signer. The signer serialises
+/// internally; what must not happen is a crossed reply or a shared transaction.
+#[tokio::test]
+async fn concurrent_intents_get_distinct_transactions() {
+    let (signer, pkh) = signer_with_key(17).await;
+    let lock = SpendCondition::simple_pkh(pkh.clone());
+    let notes: Vec<_> = (0..2)
+        .map(|i| note_for(&lock, 300 + i, 1, 500_000))
+        .collect();
+
+    let journal = tempfile::tempdir().expect("tempdir");
+    let (driver, _chain) = driver_with(signer, notes, &journal).await;
+
+    let first = {
+        let driver = Arc::clone(&driver);
+        let lock = lock.clone();
+        tokio::spawn(async move {
+            driver
+                .submit(payment(21, lock, crate::testing::hash(500), 50_000))
+                .await
+        })
+    };
+    let second = {
+        let driver = Arc::clone(&driver);
+        tokio::spawn(async move {
+            driver
+                .submit(payment(22, lock, crate::testing::hash(501), 60_000))
+                .await
+        })
+    };
+
+    let first = first.await.expect("task joins").expect("verdict reached");
+    let second = second.await.expect("task joins").expect("verdict reached");
+
+    let ids = [&first, &second].map(|outcome| match outcome {
+        TxOutcome::Submitted { id, tx_id } => (id.as_u128(), tx_id.to_base58()),
+        other => panic!("expected a submission, got {other:?}"),
+    });
+
+    assert_ne!(
+        ids[0].1, ids[1].1,
+        "both intents produced the same transaction"
+    );
+    let mut correlation: Vec<_> = ids.iter().map(|(id, _)| *id).collect();
+    correlation.sort_unstable();
+    assert_eq!(
+        correlation,
+        vec![21, 22],
+        "outcomes lost their correlation ids"
+    );
+}
+
+/// §7.5 — `signer_pkhs` feeds planning, so a note this kernel cannot open must
+/// be filtered out *there*, with a reason, rather than blowing up at signing
+/// time with an opaque kernel error.
+#[tokio::test]
+async fn a_note_the_kernel_cannot_open_never_reaches_the_signer() {
+    let (signer, _mine) = signer_with_key(23).await;
+    let (_stranger, theirs) = signer_with_key(29).await;
+
+    let their_lock = SpendCondition::simple_pkh(theirs);
+    let (name, note) = note_for(&their_lock, 400, 1, 1_000_000);
+
+    let journal = tempfile::tempdir().expect("tempdir");
+    let (driver, _chain) = driver_with(signer, vec![(name, note)], &journal).await;
+
+    let outcome = driver
+        .submit(payment(31, their_lock, crate::testing::hash(500), 100_000))
+        .await
+        .expect("verdict reached");
+
+    match outcome {
+        TxOutcome::Rejected { reason, .. } => {
+            let message = reason.to_string();
+            assert!(
+                message.contains("funds") || message.contains("no inputs"),
+                "a note the signer cannot open should read as unspendable balance, not as a \
+                 signing failure: {message}"
+            );
+        }
+        other => panic!("expected a rejection at planning time, got {other:?}"),
+    }
+}
+
+/// §7.6 — a signer that hangs must be non-terminal. A false terminal verdict
+/// strands a recoverable intent; there is nothing to roll back, because nothing
+/// was submitted.
+#[tokio::test]
+async fn a_timed_out_kernel_reports_unavailable_and_stays_recoverable() {
+    let (fast, pkh) = signer_with_key(31).await;
+    let lock = SpendCondition::simple_pkh(pkh.clone());
+    let (name, note) = note_for(&lock, 500, 1, 1_000_000);
+
+    // A second signer holding the same key, but given no time to answer.
+    let wedged = KernelSigner::new(KernelSignerConfig {
+        data_dir: None,
+        key_source: KeySource::Generate {
+            entropy: [31; 32],
+            salt: [32; 16],
+        },
+        sign_keys: Vec::new(),
+        chain_constants: Some(default_fakenet_blockchain_constants()),
+        timeout: Duration::from_nanos(1),
+    })
+    .await
+    .expect("boot happens before the timeout applies to signing");
+
+    let chain = MockChainSource::new(HEIGHT, vec![(name, note)]).with_context(chain_context());
+    let intent = payment(41, lock, crate::testing::hash(500), 100_000);
+    let (_plan, request) = plan_for(&chain, &fast, &intent).await;
+
+    let err = wedged
+        .sign(request)
+        .await
+        .expect_err("a one-nanosecond budget cannot be met");
+    assert!(
+        !err.is_terminal(),
+        "a timeout must stay retryable, but produced {err}"
+    );
+    assert!(
+        matches!(err, SignError::Unavailable(_)),
+        "expected Unavailable, got {err}"
+    );
+}
+
+/// §7.7 — the kernel's native output is a file write. Nothing here may take it
+/// up on that.
+#[tokio::test]
+async fn signing_writes_no_transaction_to_disk() {
+    let workdir = tempfile::tempdir().expect("tempdir");
+    let (signer, pkh) = signer_with_key(37).await;
+    let lock = SpendCondition::simple_pkh(pkh.clone());
+    let (name, note) = note_for(&lock, 600, 1, 1_000_000);
+
+    let chain = MockChainSource::new(HEIGHT, vec![(name, note)]).with_context(chain_context());
+    let intent = payment(51, lock, crate::testing::hash(500), 100_000);
+    let (plan, request) = plan_for(&chain, &signer, &intent).await;
+    let signed = signer.sign(request).await.expect("the kernel signs");
+    validate_signed(&plan, &signed).expect("validates");
+
+    // The kernel writes to `./txs/<name>.tx`, relative to the process working
+    // directory, so both that and the signer's own scratch space are checked.
+    let mut found = Vec::new();
+    for root in [workdir.path(), std::path::Path::new("./txs")] {
+        collect_tx_files(root, &mut found);
+    }
+    assert!(
+        found.is_empty(),
+        "a signed transaction reached the disk: {found:?}"
+    );
+}
+
+fn collect_tx_files(root: &std::path::Path, out: &mut Vec<std::path::PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(root) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_tx_files(&path, out);
+        } else if path.extension().and_then(|ext| ext.to_str()) == Some("tx") {
+            out.push(path);
+        }
+    }
+}
+
+/// §7.8 — a multisig note's note-data omits its lock, so the kernel has to be
+/// handed the participants to rebuild it. Without the `multisig` field this
+/// input is simply unspendable.
+#[tokio::test]
+async fn a_multisig_input_signs_with_the_participants_supplied() {
+    let (signer, mine) = signer_with_key(41).await;
+    let (_other, theirs) = signer_with_key(43).await;
+
+    // 1-of-2: this signer alone can satisfy it, but the lock is still m-of-n
+    // and so still needs reconstructing.
+    let lock = SpendCondition::new(vec![LockPrimitive::Pkh(Pkh::new(
+        1,
+        vec![mine.clone(), theirs],
+    ))]);
+    let (name, note) = note_for(&lock, 700, 1, 1_000_000);
+
+    let chain = MockChainSource::new(HEIGHT, vec![(name, note)]).with_context(chain_context());
+    let intent = payment(61, lock, crate::testing::hash(500), 100_000);
+    let (plan, request) = plan_for(&chain, &signer, &intent).await;
+
+    let signed = signer
+        .sign(request)
+        .await
+        .expect("the kernel rebuilds the multisig input lock and signs");
+    validate_signed(&plan, &signed).expect("validates");
+}
+
+// ---------------------------------------------------------------------------
+// Encoding tests. These need no kernel.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_simple_lock_asks_for_no_multisig_reconstruction() {
+    let mut slab: NounSlab = NounSlab::new();
+    let plan = crate::sign::tests::plan_with(vec![(crate::testing::hash(50), 900)], 50);
+    let request = SignRequest::new(
+        IntentId::from_u128(1),
+        plan,
+        Vec::new(),
+        crate::sign::tests::chain_state(),
+        Vec::new(),
+    );
+    let noun = multisig_noun(&mut slab, &request).expect("encodes");
+    assert!(
+        unsafe { noun.raw_equals(&D(0)) },
+        "a 1-of-1 pkh lock is one the kernel can already derive; sending a reconstruction \
+         payload would make it rebuild a lock it did not need"
+    );
+}
+
+#[test]
+fn two_distinct_multisig_locks_are_refused_rather_than_silently_truncated() {
+    // The cause has room for exactly one reconstructed input lock. Picking one
+    // and dropping the other would produce a transaction that fails to unlock
+    // half its inputs, which is far worse than declining.
+    let mut slab: NounSlab = NounSlab::new();
+    let mut plan = crate::sign::tests::plan_with(vec![(crate::testing::hash(50), 900)], 50);
+    plan.spend_conditions = vec![
+        SpendCondition::new(vec![LockPrimitive::Pkh(Pkh::new(
+            2,
+            vec![crate::testing::hash(1), crate::testing::hash(2)],
+        ))]),
+        SpendCondition::new(vec![LockPrimitive::Pkh(Pkh::new(
+            2,
+            vec![crate::testing::hash(3), crate::testing::hash(4)],
+        ))]),
+    ];
+    let request = SignRequest::new(
+        IntentId::from_u128(1),
+        plan,
+        Vec::new(),
+        crate::sign::tests::chain_state(),
+        Vec::new(),
+    );
+
+    let err = multisig_noun(&mut slab, &request).expect_err("two locks cannot both be sent");
+    assert!(matches!(err, SignError::Declined(_)));
+}
+
+#[test]
+fn a_kernel_that_reselected_inputs_is_named_as_a_parity_failure() {
+    // The diagnosis matters: `validate_signed` would report this as a generic
+    // `SignerMismatch` two layers up, which reads like a broken signature
+    // rather than a kernel that ignored the `names` list.
+    let plan = crate::sign::tests::plan_with(vec![(crate::testing::hash(50), 900)], 50);
+    let request = SignRequest::new(
+        IntentId::from_u128(1),
+        plan,
+        Vec::new(),
+        crate::sign::tests::chain_state(),
+        Vec::new(),
+    );
+    let substituted = crate::sign::tests::signed_with(
+        Name::new(crate::testing::hash(999), crate::testing::hash(998)),
+        vec![(crate::testing::hash(50), 900)],
+        50,
+    );
+
+    let err = ensure_input_parity(&request, &substituted).expect_err("inputs differ");
+    assert!(
+        err.to_string().contains("parity"),
+        "the message should name the actual problem: {err}"
+    );
+    assert!(err.is_terminal(), "a re-planning kernel will re-plan again");
+}
+
+#[test]
+fn a_kernel_reply_bearing_key_material_is_never_forwarded() {
+    // `kernel_explanation` feeds a `SignError`, which the driver journals to
+    // disk and pokes back to the kernel. The wallet's `%markdown` channel is
+    // also how it prints seed phrases, so the two must never meet. This is the
+    // shape of a real `keygen` reply.
+    let mut slab: NounSlab = NounSlab::new();
+    let tag = make_tas(&mut slab, "markdown").as_noun();
+    let body = make_tas(
+        &mut slab,
+        "## Generated New Master Key\n### Seed Phrase (save this for import)\n\
+         'only ten inspire accuse upgrade wheat witness wood amount oppose amateur maximum'\n\
+         ### Extended Private Key (save this for import)\nzprvLxxkCBq3s5HYzkem5RVqpGdAz",
+    )
+    .as_noun();
+    let noun = T(&mut slab, &[tag, body]);
+    slab.set_root(noun);
+
+    let explanation = kernel_explanation(std::slice::from_ref(&slab));
+    for leak in ["only ten inspire", "zprv", "Seed Phrase"] {
+        assert!(
+            !explanation.contains(leak),
+            "key material reached an error string via {leak:?}: {explanation}"
+        );
+    }
+    assert!(
+        explanation.contains("redacted"),
+        "the drop should be visible: {explanation}"
+    );
+}
+
+#[test]
+fn an_ordinary_kernel_complaint_is_still_forwarded_verbatim() {
+    // Redaction must not swallow the diagnostic that makes a stale kernel
+    // recognisable, or the filter above just trades one silent failure for
+    // another.
+    let mut slab: NounSlab = NounSlab::new();
+    let tag = make_tas(&mut slab, "markdown").as_noun();
+    let body = make_tas(&mut slab, "## Poke failed").as_noun();
+    let noun = T(&mut slab, &[tag, body]);
+    slab.set_root(noun);
+
+    assert_eq!(
+        kernel_explanation(std::slice::from_ref(&slab)),
+        "## Poke failed"
+    );
+}

--- a/crates/tx-driver/src/lib.rs
+++ b/crates/tx-driver/src/lib.rs
@@ -24,6 +24,14 @@
 //! external authority is involved: [`chain::ChainSource`] for the network and
 //! [`sign::Signer`] for key material. Neither the planner nor the driver ever
 //! sees a private key.
+//!
+//! # Signers
+//!
+//! [`sign::RemoteSigner`] covers a signer reached over some transport. Behind
+//! the `kernel-signer` feature, [`kernel_signer::KernelSigner`] drives a
+//! resident Hoon wallet kernel — the only thing in this repository that can
+//! actually produce a Schnorr signature. It is feature-gated because it pulls
+//! in the wallet kernel image, which a host that signs elsewhere does not want.
 
 // Tests use `unwrap` freely; a panic there is the failure signal.
 #![cfg_attr(test, allow(clippy::unwrap_used))]
@@ -34,6 +42,8 @@ pub mod driver;
 pub mod error;
 pub mod intent;
 pub mod journal;
+#[cfg(feature = "kernel-signer")]
+pub mod kernel_signer;
 #[cfg(feature = "nockapp-driver")]
 pub mod nockapp;
 pub mod notes;
@@ -45,5 +55,7 @@ pub use chain::{BalanceSnapshot, ChainSource, GrpcChainSource, SubmitStatus};
 pub use driver::{ConfirmPolicy, TxDriver, TxDriverConfig};
 pub use error::{JournalError, RejectReason, Result, TxDriverError};
 pub use intent::{FeePolicy, IntentId, NoteSelection, Recipient, TxIntent, TxOutcome};
+#[cfg(feature = "kernel-signer")]
+pub use kernel_signer::{KernelSigner, KernelSignerConfig, KeySource};
 pub use notes::{ClassifiedNotes, SpendConditionMatcher, UnlockContext, UnspendableReason};
-pub use sign::{SignError, SignRequest, Signer};
+pub use sign::{ChainState, SignError, SignRequest, Signer};

--- a/crates/tx-driver/src/sign.rs
+++ b/crates/tx-driver/src/sign.rs
@@ -25,7 +25,7 @@
 use std::collections::BTreeMap;
 
 use async_trait::async_trait;
-use nockchain_types::tx_engine::common::{Hash, Name, TxId};
+use nockchain_types::tx_engine::common::{BlockHeight, Hash, Name, TxId};
 use nockchain_types::tx_engine::v1;
 use nockchain_types::tx_engine::v1::tx::{Spend, SpendCondition};
 use wallet_tx_builder::types::CandidateNote;
@@ -49,16 +49,44 @@ pub struct SignRequest {
     pub notes: Vec<CandidateNote>,
     /// The spend conditions unlocking those notes, deduplicated.
     pub spend_conditions: Vec<SpendCondition>,
+    /// The chain state the plan was made against.
+    ///
+    /// A signer that wants to check a timelock, or that has to reproduce the
+    /// plan against a kernel of its own, needs the same height the planner
+    /// used. Without it a signer either guesses or fetches its own — and two
+    /// views of the chain means a plan the signer cannot reproduce.
+    pub chain_state: ChainState,
+    /// The notes being spent, in the form a balance snapshot carries them.
+    ///
+    /// `notes` is the planner's projection and is lossy; this is the value the
+    /// chain reported. A signer that must seed a wallet with the balance it is
+    /// spending needs the latter.
+    pub spent_notes: Vec<(Name, v1::Note)>,
+}
+
+/// The chain state a plan was made against.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ChainState {
+    pub height: BlockHeight,
+    pub block_id: Hash,
 }
 
 impl SignRequest {
-    pub fn new(intent_id: IntentId, plan: TxPlan, notes: Vec<CandidateNote>) -> Self {
+    pub fn new(
+        intent_id: IntentId,
+        plan: TxPlan,
+        notes: Vec<CandidateNote>,
+        chain_state: ChainState,
+        spent_notes: Vec<(Name, v1::Note)>,
+    ) -> Self {
         let spend_conditions = plan.spend_conditions.clone();
         Self {
             intent_id,
             plan,
             notes,
             spend_conditions,
+            chain_state,
+            spent_notes,
         }
     }
 
@@ -381,6 +409,13 @@ pub(crate) mod tests {
         Name::new(hash(seed), hash(seed + 1000))
     }
 
+    pub(crate) fn chain_state() -> ChainState {
+        ChainState {
+            height: BlockHeight(Belt(1000)),
+            block_id: hash(7),
+        }
+    }
+
     /// A plan spending one note, paying `outputs`, charging `fee`.
     pub(crate) fn plan_with(outputs: Vec<(Hash, u64)>, fee: u64) -> TxPlan {
         TxPlan {
@@ -615,7 +650,13 @@ pub(crate) mod tests {
 
         assert_eq!(signer.signer_pkhs().await.unwrap(), vec![hash(1)]);
         let plan = plan_with(vec![(hash(50), 900)], 50);
-        let request = SignRequest::new(IntentId::from_u128(1), plan.clone(), vec![]);
+        let request = SignRequest::new(
+            IntentId::from_u128(1),
+            plan.clone(),
+            vec![],
+            chain_state(),
+            vec![],
+        );
         let signed = signer.sign(request).await.expect("signs");
         validate_signed(&plan, &signed).expect("validates");
     }

--- a/crates/tx-driver/src/testing.rs
+++ b/crates/tx-driver/src/testing.rs
@@ -104,6 +104,16 @@ impl MockChainSource {
         }
     }
 
+    /// Replaces the fee constants and height this chain reports.
+    ///
+    /// Needed whenever the transaction goes on to be priced somewhere else as
+    /// well — a wallet kernel re-checks the fee against its own constants — so
+    /// that both sides are working from the same numbers.
+    pub fn with_context(mut self, context: ChainContext) -> Self {
+        self.context = context;
+        self
+    }
+
     /// Never confirms submitted transactions; they sit in the mempool.
     pub fn never_confirming(mut self) -> Self {
         self.confirm_at = None;


### PR DESCRIPTION
Implements `tx_driver::kernel_signer::KernelSigner`, the last unimplemented piece of the driver — a `Signer` that produces real Schnorr signatures by driving a booted Hoon wallet kernel. Design per `crates/tx-driver/KERNEL_SIGNER_SPEC.md`.

Gated behind a non-default `kernel-signer` feature, so a host that signs remotely (service, extension, WASM) does not pull in the wallet kernel image or the prover hot state.

## Pinning the kernel to the driver's plan

`create-tx` is not "sign this transaction" — it builds *and* signs, picking its own inputs, fee, and change. The driver has already decided all three, and a disagreement yields a transaction it never asked for. Three things constrain it:

- **Inputs** are named explicitly, leaving the selector one legal answer.
- **The fee** is passed as a number, with `allow-low-fee` false — if the kernel thinks it's low, that's a parity failure worth hearing about.
- **Every output, change included,** goes over as a `%lock-root` order. This is the load-bearing bit: the driver's plan already contains the change, so handing the orders over *complete* makes `inputs − orders − fee = 0`, and the kernel's refund logic drops out (`+create-spends-1` in `tx-builder.hoon` omits a zero refund). `%lock-root` also carries no note-data — matching `include_data: false` in the planner — and can express a `Destination::Tree` or bare lock root that the `%pkh` and `%multisig` orders cannot.

I verified the poke encoder is byte-identical to the wallet CLI's `encode_create_tx_request` for the case they share.

## Deltas from the spec

- **No IO driver and no `run()`.** `NockApp::poke_timeout` returns a poke's effects directly, so the kernel just lives in a task serving jobs off a channel. §6's `%exit` hazard dissolves — and `do-create-tx` emits no `%exit` on success anyway.
- **`SignRequest` gains `chain_state` and `spent_notes`.** More than §4.2's note on height: seeding the kernel's balance needs the notes as the chain reported them, and `CandidateNote` is a lossy projection.
- **The `nockchain-wallet` lib target (§8) is not done.** The encoder we need isn't the one that exists — ours sends all-outputs-as-`%lock-root` with no refund. If reuse is wanted later, moving the cause encoder into `wallet-tx-builder` (already a shared dependency) beats making the CLI binary a library.

## Security

- Nothing is written to disk; the signed transaction is decoded from the `%file` effect in memory.
- `KeySource` has a redacting `Debug`, so key material can't leak through a stray `{:?}`.
- Kernel output is scrubbed of key-material markers before it can reach a `SignError`. That string gets journalled and poked back to the kernel, and `%markdown` is also how the wallet prints seed phrases — today only the `create-tx` reply reaches that path, but that's a fact about the call graph, not a property of the function.

## Testing

```
cargo test -p tx-driver                          # 88 passed (baseline unchanged)
cargo test -p tx-driver --features kernel-signer  # 101 passed
cargo clippy -p tx-driver --all-targets           # clean, both feature sets
```

The full §7 suite runs against a real booted kernel: round trip, planner parity, residency, concurrency, truthful `signer_pkhs`, timeout, no disk writes, multisig.

One test earned its keep. §7.6 caught a real bug: `poke_timeout` reports a lapsed deadline as `CrownError::Timeout`, not `NockAppError::Timeout`. Missing that variant classified a hung kernel as a **terminal** rejection — stranding an intent that was still recoverable and had submitted nothing.

## Heads-up: `make` never rebuilds kernel jams

Unrelated to this change, but it cost a while to find. `Makefile:254` reads:

```make
HOON_SRCS := $(find hoon -type file -name '*.hoon')
```

That's a bare `$(find ...)`, not `$(shell find ...)`, so it expands to the empty string. Every jam rule lists `$(HOON_SRCS)` as a prerequisite that is always empty, so a kernel is rebuilt only when its own entry point changes — never when a library beneath it does. `wallet.hoon` hasn't changed since May; `types.hoon` grew the `multisig` field on `create-tx-cause` in June; make has considered `assets/wal.jam` up to date ever since.

A stale wallet kernel rejects the `create-tx` poke outright, including the `nockchain-wallet` CLI's own. On this branch it was silently failing 8 existing wallet tests — `cargo test -p nockchain-wallet` goes from 101 passed / 8 failed to **109 passed / 0 failed** after `make assets/wal.jam`.

I have not touched the Makefile: the one-line fix triggers a ~20-minute rebuild of six kernels for everyone, which seems like a call for you to make. `dumb`, `miner`, `peek`, `bridge`, and `roswell` are affected identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)